### PR TITLE
Fixes performance of distinct queries (#83)

### DIFF
--- a/src/main/scala/collection.scala
+++ b/src/main/scala/collection.scala
@@ -120,16 +120,12 @@ object JSONBatchCommands
   implicit object DistinctResultReader
     extends pack.Reader[DistinctCommand.DistinctResult] {
 
-    import scala.collection.immutable.ListSet
-
     private val path = JsPath \ "values"
 
     def reads(js: JsValue): JsResult[DistinctCommand.DistinctResult] =
       (js \ "values").toEither match {
         case Right(JsArray(values)) =>
-          JsSuccess(DistinctCommand.DistinctResult(
-            ListSet.empty[JsValue] ++ values
-          ))
+          JsSuccess(DistinctCommand.DistinctResult(values.toList))
 
         case Right(v)    => JsError(path, s"invalid JSON: $v")
         case Left(error) => JsError(Seq(path -> Seq(error)))


### PR DESCRIPTION
Fixes #83, since the results from Mongo are already distinct, there seems to be no reason to use ListSet. In the main library, a call to List.tail will be a very cheap call.