### PR TITLE
feature/ add BSONDecimal format support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ val mimaSettings = mimaDefaultSettings ++ Seq(
       // ValidationError breaking change in Play 2.6
       (Seq("ObjectID", "Binary", "String", "Symbol", "MaxKey", "Undefined",
         "Long", "Array", "Null", "MinKey", "DateTime", "Integer", "Double",
-        "Timestamp", "Regex", "Document", "Boolean", "JavaScript").
+        "Timestamp", "Regex", "Document", "Boolean", "JavaScript", "Decimal").
         flatMap { t =>
           Seq("filter", "filterNot", "collect").map { m =>
             ProblemFilters.exclude[IncompatibleMethTypeProblem](
@@ -188,15 +188,14 @@ val mimaSettings = mimaDefaultSettings ++ Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.reactivemongo$play$json$BSONFormats$_setter_$reactivemongo$play$json$BSONFormats$$defaultWrite_="),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.reactivemongo$play$json$BSONFormats$_setter_$reactivemongo$play$json$BSONFormats$$defaultRead_="),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.reactivemongo$play$json$BSONFormats$$defaultWrite"),
-      ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.libs.json.Reads.reads"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.BSONDecimalFormat"),
+        ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.libs.json.Reads.reads"),
       ProblemFilters.exclude[MissingClassProblem](
         "reactivemongo.play.json.BSONFormats$BSONTimestampFormat$TimeValue$"),
       ProblemFilters.exclude[MissingClassProblem](
         "reactivemongo.play.json.BSONFormats$BSONDateTimeFormat$DateValue$"),
       ProblemFilters.exclude[MissingClassProblem](
         "reactivemongo.play.json.BSONFormats$BSONObjectIDFormat$OidValue$"),
-      ProblemFilters.exclude[MissingClassProblem](
-        "reactivemongo.play.json.BSONFormats$BSONDecimalFormat$DecimalValue$"),
       ProblemFilters.exclude[MissingClassProblem]("reactivemongo.play.json.BSONFormats$BSONJavaScriptFormat$JavascriptValue$"),
       ProblemFilters.exclude[MissingClassProblem]("reactivemongo.play.json.BSONFormats$BSONSymbolFormat$SymbolValue$"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](

--- a/build.sbt
+++ b/build.sbt
@@ -195,6 +195,8 @@ val mimaSettings = mimaDefaultSettings ++ Seq(
         "reactivemongo.play.json.BSONFormats$BSONDateTimeFormat$DateValue$"),
       ProblemFilters.exclude[MissingClassProblem](
         "reactivemongo.play.json.BSONFormats$BSONObjectIDFormat$OidValue$"),
+      ProblemFilters.exclude[MissingClassProblem](
+        "reactivemongo.play.json.BSONFormats$BSONDecimalFormat$DecimalValue$"),
       ProblemFilters.exclude[MissingClassProblem]("reactivemongo.play.json.BSONFormats$BSONJavaScriptFormat$JavascriptValue$"),
       ProblemFilters.exclude[MissingClassProblem]("reactivemongo.play.json.BSONFormats$BSONSymbolFormat$SymbolValue$"),
       ProblemFilters.exclude[ReversedMissingMethodProblem](

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,7 @@ val mimaSettings = mimaDefaultSettings ++ Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.reactivemongo$play$json$BSONFormats$_setter_$reactivemongo$play$json$BSONFormats$$defaultRead_="),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.reactivemongo$play$json$BSONFormats$$defaultWrite"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("reactivemongo.play.json.BSONFormats.BSONDecimalFormat"),
-        ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.libs.json.Reads.reads"),
+      ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.libs.json.Reads.reads"),
       ProblemFilters.exclude[MissingClassProblem](
         "reactivemongo.play.json.BSONFormats$BSONTimestampFormat$TimeValue$"),
       ProblemFilters.exclude[MissingClassProblem](

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -645,7 +645,6 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
     dateTime: PartialReads[BSONDateTime],
     timestamp: PartialReads[BSONTimestamp],
     binary: PartialReads[BSONBinary],
-    decimal: PartialReads[BSONDecimal],
     regex: PartialReads[BSONRegex],
     double: PartialReads[BSONDouble],
     integer: PartialReads[BSONInteger],
@@ -657,7 +656,8 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
     symbol: PartialReads[BSONSymbol],
     array: PartialReads[BSONArray],
     doc: PartialReads[BSONDocument],
-    undef: PartialReads[BSONUndefined.type]
+    undef: PartialReads[BSONUndefined.type],
+    decimal: PartialReads[BSONDecimal]
   ): JsResult[BSONValue] =
     string.partialReads.
       orElse(objectID.partialReads).
@@ -691,7 +691,6 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
     objectID: PartialWrites[BSONObjectID],
     javascript: PartialWrites[BSONJavaScript],
     dateTime: PartialWrites[BSONDateTime],
-    decimal: PartialWrites[BSONDecimal],
     timestamp: PartialWrites[BSONTimestamp],
     binary: PartialWrites[BSONBinary],
     regex: PartialWrites[BSONRegex],
@@ -705,7 +704,8 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
     symbol: PartialWrites[BSONSymbol],
     array: PartialWrites[BSONArray],
     doc: PartialWrites[BSONDocument],
-    undef: PartialWrites[BSONUndefined.type]
+    undef: PartialWrites[BSONUndefined.type],
+    decimal: PartialWrites[BSONDecimal]
   ): JsValue = string.partialWrites.
     orElse(objectID.partialWrites).
     orElse(javascript.partialWrites).

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -289,7 +289,7 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
   implicit object BSONDecimalFormat extends PartialFormat[BSONDecimal] {
 
     val partialReads: PartialFunction[JsValue, JsResult[BSONDecimal]] = {
-      case DecimalRead(v) => JsSuccess(BSONDecimal(v._1, v._2))
+      case DecimalRead(v) => JsSuccess(v)
     }
 
     val partialWrites: PartialFunction[BSONValue, JsValue] = {
@@ -310,7 +310,7 @@ sealed trait BSONFormats extends LowerImplicitBSONHandlers {
 
     private val strict: PartialFunction[JsValue, Option[BSONDecimal]] = {
       case JsNumber(n) => BSONDecimal.fromBigDecimal(n).toOption
-      case JsString(n) => Try(BigDecimal(n)).map(BSONDecimal.fromBigDecimal).flatten.toOption
+      case JsString(n) => Try(BigDecimal(n)).flatMap(BSONDecimal.fromBigDecimal).toOption
       case _           => None
     }
 

--- a/src/test/scala/BSONFormatsSpec.scala
+++ b/src/test/scala/BSONFormatsSpec.scala
@@ -186,7 +186,7 @@ object BSONFormatsSpec extends org.specs2.mutable.Specification {
       }
     }
 
-    "handle BSONDecimal from strict extended syntax" in {
+    "handle BSONDecimal from legacy extended syntax" in {
       val decimal = BigDecimal(0.7)
       val bs = BSONDecimal.fromBigDecimal(decimal).get
       val jbs = Json.obj(f"$$decimal" -> Json.obj(f"$$numberDecimal" -> decimal))

--- a/src/test/scala/BSONFormatsSpec.scala
+++ b/src/test/scala/BSONFormatsSpec.scala
@@ -181,8 +181,14 @@ object BSONFormatsSpec extends org.specs2.mutable.Specification {
       val decimal = BigDecimal(0.7)
       val bs = BSONDecimal.fromBigDecimal(decimal).get
       val jbs = Json.obj(f"$$decimal" -> decimal)
+      val jbs1 = Json.obj(f"$$decimal" -> "0.7")
+
       Json.fromJson[BSONDecimal](jbs) must beLike {
         case JsSuccess(res, _) => res must_=== bs
+      } and {
+        Json.fromJson[BSONDecimal](jbs1) must beLike {
+          case JsSuccess(res, _) => res must_=== bs
+        }
       }
     }
 
@@ -190,8 +196,14 @@ object BSONFormatsSpec extends org.specs2.mutable.Specification {
       val decimal = BigDecimal(0.7)
       val bs = BSONDecimal.fromBigDecimal(decimal).get
       val jbs = Json.obj(f"$$decimal" -> Json.obj(f"$$numberDecimal" -> decimal))
+      val jbs1 = Json.obj(f"$$decimal" -> Json.obj(f"$$numberDecimal" -> 0.7))
+
       Json.fromJson[BSONDecimal](jbs) must beLike {
         case JsSuccess(res, _) => res must_=== bs
+      } and {
+        Json.fromJson[BSONDecimal](jbs1) must beLike {
+          case JsSuccess(res, _) => res must_=== bs
+        }
       }
     }
 

--- a/src/test/scala/BSONFormatsSpec.scala
+++ b/src/test/scala/BSONFormatsSpec.scala
@@ -177,6 +177,24 @@ object BSONFormatsSpec extends org.specs2.mutable.Specification {
       }
     }
 
+    "handle BSONDecimal from strict extended syntax" in {
+      val decimal = BigDecimal(0.7)
+      val bs = BSONDecimal.fromBigDecimal(decimal).get
+      val jbs = Json.obj(f"$$decimal" -> decimal)
+      Json.fromJson[BSONDecimal](jbs) must beLike {
+        case JsSuccess(res, _) => res must_=== bs
+      }
+    }
+
+    "handle BSONDecimal from strict extended syntax" in {
+      val decimal = BigDecimal(0.7)
+      val bs = BSONDecimal.fromBigDecimal(decimal).get
+      val jbs = Json.obj(f"$$decimal" -> Json.obj(f"$$numberDecimal" -> decimal))
+      Json.fromJson[BSONDecimal](jbs) must beLike {
+        case JsSuccess(res, _) => res must_=== bs
+      }
+    }
+
     "handle BSONDocument" in {
       val json = Json.obj(
         "age" -> 4,


### PR DESCRIPTION
## Feature
simulate BSONDateTime add BSONDecimal format support

## Purpose
```
# environment: mongo3.4, play2.5.x, reactivemongo-0.17.1-play25
we want use mongo3.4 new Feature NumberDecimal got error

# in mongo
mongo_shell> db.test.insert({a:NumberDecimal(0.7)})

# in play fetch data with cursor[JsObject] got error
play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[JSONException: Unhandled json value: 0.7]]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:269)
	at play.api.http.DefaultHttpErrorHandler.onServerError(HttpErrorHandler.scala:195)
	at play.api.GlobalSettings$class.onError(GlobalSettings.scala:160)
	at Global$.onError(Global.scala:51)
	at play.api.http.GlobalSettingsHttpErrorHandler.onServerError(HttpErrorHandler.scala:98)
	at play.core.server.netty.PlayRequestHandler$$anonfun$2$$anonfun$apply$1.applyOrElse(PlayRequestHandler.scala:99)
	at play.core.server.netty.PlayRequestHandler$$anonfun$2$$anonfun$apply$1.applyOrElse(PlayRequestHandler.scala:98)
	at scala.concurrent.Future$$anonfun$recoverWith$1.apply(Future.scala:346)
	at scala.concurrent.Future$$anonfun$recoverWith$1.apply(Future.scala:345)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:36)
```

## Reference
[NumberDecimal](#https://docs.mongodb.com/manual/core/shell-types/index.html#numberdecimal)